### PR TITLE
Add Wiki Loves Africa 2020

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -31,6 +31,13 @@
 			"startDate": "2020-05-01",
 			"endDate": "2020-07-31",
 			"link": "https://commons.wikimedia.org/wiki/Commons:Wiki_Loves_Earth_2020"
+		},
+		{
+			"title": "Wiki Loves Africa",
+			"description": "2020 Theme: \"Africa on the Move or Transport\"",
+			"startDate": "2020-02-15",
+			"endDate": "2020-03-31",
+			"link": "https://commons.wikimedia.org/wiki/Commons:Wiki_Loves_Africa_2020"
 		}
 	]
 }


### PR DESCRIPTION
Adds the Wiki Loves Africa 2020 campaign.

Wiki Loves Africa 2020: https://commons.wikimedia.org/wiki/Commons:Wiki_Loves_Africa_2020