### PR TITLE
campaigns: update Wiki Loves Monument entry for 2021

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -13,10 +13,10 @@
 		},
 		{
 			"title": "Wiki Loves Monuments",
-			"description": "A public photo competition around cultural heritage monuments",
-			"startDate": "2020-09-01",
-			"endDate": "2020-09-30",
-			"link": "https://commons.wikimedia.org/wiki/Commons:Wiki_Loves_Monuments_2020"
+			"description": "A public photo competition around cultural heritage monuments in various countries",
+			"startDate": "2021-09-01",
+			"endDate": "2021-10-31",
+			"link": "https://commons.wikimedia.org/wiki/Commons:Wiki_Loves_Monuments_2021"
 		},
 		{
 			"title": "Wiki Loves Pride",


### PR DESCRIPTION
The duration is two months as the dates are different in different
countries. The description has also been tweaked to mention that the
campaign is country specific.

Let me know if the rephrase of the description sounds strange.