### PR TITLE
campaigns: change duration of WLM 2021

### DIFF
--- a/campaigns.json
+++ b/campaigns.json
@@ -15,7 +15,7 @@
 			"title": "Wiki Loves Monuments",
 			"description": "A public photo competition around cultural heritage monuments in various countries",
 			"startDate": "2021-09-01",
-			"endDate": "2021-10-31",
+			"endDate": "2021-09-30",
 			"link": "https://commons.wikimedia.org/wiki/Commons:Wiki_Loves_Monuments_2021"
 		},
 		{

--- a/campaigns.json
+++ b/campaigns.json
@@ -19,13 +19,6 @@
 			"link": "https://commons.wikimedia.org/wiki/Commons:Wiki_Loves_Monuments_2021"
 		},
 		{
-			"title": "Wiki Loves Monuments",
-			"description": "A public photo competition around cultural heritage monuments in a few countries like Brazil, Malaysia etc.",
-			"startDate": "2021-10-01",
-			"endDate": "2021-10-31",
-			"link": "https://commons.wikimedia.org/wiki/Commons:Wiki_Loves_Monuments_2021"
-		},
-		{
 			"title": "Wiki Loves Pride",
 			"description": "Global campaign to expand and improve LGBT+ content",
 			"startDate": "2020-06-19",

--- a/campaigns.json
+++ b/campaigns.json
@@ -19,6 +19,13 @@
 			"link": "https://commons.wikimedia.org/wiki/Commons:Wiki_Loves_Monuments_2021"
 		},
 		{
+			"title": "Wiki Loves Monuments",
+			"description": "A public photo competition around cultural heritage monuments in a few countries like Brazil, Malaysia etc.",
+			"startDate": "2021-10-01",
+			"endDate": "2021-10-31",
+			"link": "https://commons.wikimedia.org/wiki/Commons:Wiki_Loves_Monuments_2021"
+		},
+		{
 			"title": "Wiki Loves Pride",
 			"description": "Global campaign to expand and improve LGBT+ content",
 			"startDate": "2020-06-19",


### PR DESCRIPTION
The duration is two months as the dates are different in different
countries. The description has also been tweaked to mention that the
campaign is country specific.This is being done per [[ref][1]], the essence of which is:

> The international organizers have told [...] that they
prefer we set the date constraints to 1 Sep - 30 Sep, as
most countries are using those dates and they don't want
people to be uploading monuments after the deadline and
then wondering why their uploads are not included in the
competition.

[1]: https://github.com/commons-app/apps-android-commons/issues/4552#issuecomment-906611143

I also added another entry for 01Oct2021-31Oct2021 as completely leaving out the banner seemed incorrect to me. Let me know if that feels a little too much.

cc @misaochan 