### PR TITLE
Replace Travis with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,28 @@
+name: schema check
+
+on:
+  push
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout ${{ github.sha }}
+        uses: actions/checkout@v3
+
+      - name: Install Ajv CLI
+        run: npm i -g ajv-cli
+
+      - name: Validate campaigns.json
+        run: ajv validate --errors=text -s schema.json -d campaigns.json
+
+      - name: Validate campaigns_beta_active.json
+        run: ajv validate --errors=text -s schema.json -d campaigns_beta_active.json
+
+      - name: Validate campaigns_beta_inactive.json
+        run: ajv validate --errors=text -s schema.json -d campaigns_beta_inactive.json
+
+      - name: Validate campaigns_beta_none.json
+        run: ajv validate --errors=text -s schema.json -d campaigns_beta_none.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: generic
-install: npm i -g ajv-cli
-script:
-- ajv validate --errors=text -s schema.json -d campaigns.json
-- ajv validate --errors=text -s schema.json -d campaigns_beta_active.json
-- ajv validate --errors=text -s schema.json -d campaigns_beta_inactive.json
-- ajv validate --errors=text -s schema.json -d campaigns_beta_none.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Commons campaigns
 
-The `campaigns.json` file contains information (title, description, dates, link) about Commons campaigns such as Wiki Loves Monuments.
+The [`campaigns.json`](https://github.com/commons-app/campaigns/blob/master/campaigns.json) file contains information (title, description, dates, link) about Commons campaigns such as Wiki Loves Monuments.
 
 Campaigns will be advertised in the [Commons Android app](https://github.com/commons-app/apps-android-commons/) using this information.
 
@@ -11,13 +11,19 @@ All campaigns found [here](https://commons.wikimedia.org/wiki/Category:Photograp
 If a campaign is not documented yet, or to modify the dates or URL, please:
 
 1. Go to the [campaign editor](https://commons-app.github.io/campaigns-editor/)
-2. Click `Import` > `Live version`, then click `Add` and enter the details for the campaign
+2. Click `Add` and enter the details for the campaign
 3. Scroll down to the result, click `Copy to clipboard` and then `Edit on GitHub`
 4. Delete the existing content, and paste in the updated campaigns file
 5. In the pull request description, provide a source for the information, for instance a link to an announcement or wiki discussion
 6. We will review your contribution and merge it
-7. After it is merged, please check in the app whether it is displaying and behaving correctly, and report any problem
+7. After your PR is merged, check the app displays the campaign correctly and report any problems
 
 Thanks!
 
-If for any reason you prefer to edit the JSON file manually, please validate it using a JSON validator such as [JSONLint](https://jsonlint.com) before sending the pull request.
+## Using the campaigns data
+
+Make a GET request to the GitHub API to fetch the JSON file. For example:
+
+```
+curl -X GET https://raw.githubusercontent.com/commons-app/campaigns/master/campaigns.json
+```


### PR DESCRIPTION
Travis CI hasn't been working since early 2021. This PR replaces it with GitHub Actions, as we did for the main app (see https://github.com/commons-app/apps-android-commons/issues/4091).

Also makes some minor changes to the README to:
- reflect updates to the editor
- remove redundant sentence about checking with JSONLint (as now CI does this already)
- add a bit on how to use this as an API